### PR TITLE
feat: add Trello board panel in lower-right slot

### DIFF
--- a/services/desktop_dashboard_service/architecture/current-specification.md
+++ b/services/desktop_dashboard_service/architecture/current-specification.md
@@ -164,6 +164,12 @@ The built-in `waste_collection_text` renderer accepts waste collection data and 
   - defaults to `city = "Eichenau"` and `timezone = "Europe/Berlin"`
   - accepts `address` or `street` + optional `house_number`
   - supports optional `waste_type` or `waste_types` filtering
+- `trello_cards` backed by the Trello REST API (read-only token scope required)
+  - requires `source_config.api_key` and `source_config.token`; supply via `secrets.toml` placeholders
+  - requires `source_config.board_id`
+  - supports optional `source_config.list_names` (list of column names, case-insensitive substring match) to restrict which lists are shown
+  - supports optional `source_config.max_cards` (default 20)
+  - maps HTTP, network, and JSON errors to `SourceUnavailableError`
 
 ### Renderers
 
@@ -174,6 +180,7 @@ The built-in `waste_collection_text` renderer accepts waste collection data and 
 - `weather_block` (self-contained PIL image: today overview + 4-h blocks + tomorrow row)
 - `train_departures_text` — the station name header is a **bold** `RichLine`; each departure is rendered as a single timetable row (one `StyledLine`) containing the line label, departure time, and destination on the same line.  The line label is shown in **bold** for the first occurrence; subsequent departures sharing the same line label use space padding to keep the time column aligned.  On-time departures show the scheduled time without emphasis.  Delayed or early departures hide the scheduled time and show only the actual (realtime) time in **bold** — preventing two full HH:MM values from appearing side-by-side.  Cancelled departures show the scheduled time as strikethrough followed by "Cancelled" and the destination.  When `first-departure-font-size` is set in `renderer_config`, the first (next) departure row is rendered at that font size to give it visual emphasis over subsequent rows; if not set, `departure-font-size` applies to all rows.
 - `waste_collection_text` — renders upcoming AWB waste collection dates for a short look-ahead window, includes the waste type on each line, and emphasizes tomorrow with **bold** larger text
+- `trello_cards_text` — renders open Trello cards grouped under bold list-name headers; each card is prefixed with `•`; renders `"No cards"` when the board returns no matching cards
 
 ## Output contract
 
@@ -207,7 +214,7 @@ The built-in `waste_collection_text` renderer accepts waste collection data and 
 - `train_departures_text` renders each departure as a single timetable row: line label (bold on first occurrence of each line, space-padded on subsequent same-line rows), one displayed time, destination — all on one line.
 - On-time departures display the scheduled time. Delayed or early departures hide the scheduled time and display only the actual time in **bold**. Cancelled departures display the scheduled time as strikethrough.
 - When `first-departure-font-size` is set, the first departure row is rendered at that font size for visual emphasis; subsequent rows use `departure-font-size`.
-- The layout slot bounding boxes in `layout.svg` must not overlap; the two-zone layout separates the left context rail (x 0–182) from the main content area (x 188–800), with the weather block in the main area top section (height 168 px), one Google Calendar block beneath it, waste collection in the lower rail, and the transport timetable spanning the full lower-main width.
+- The layout slot bounding boxes in `layout.svg` must not overlap; the two-zone layout separates the left context rail (x 0–182) from the main content area (x 188–800), with the weather block in the main area top section (height 168 px), one Google Calendar block beneath it, waste collection in the lower rail, the transport timetable in the lower-main left portion (x 244–524, width 280 px), and the Trello board panel in the lower-main right portion (x 542–792, width 250 px) separated by a vertical divider at x=534.
 - `analog_clock` renders an outer circle, optional tick marks, and an optional hour hand, with no minute hand and no second hand.
 - `analog_clock` `sector_style = "outer_arc"` (default) renders a highlighted thick arc along the clock rim spanning the validity window.
 - `analog_clock` `sector_style = "end_hand"` renders a single long hand pointing to the end of the validity window instead of an arc.
@@ -232,3 +239,8 @@ The built-in `waste_collection_text` renderer accepts waste collection data and 
 - `waste_collection_text` renders only entries due within the configured look-ahead window relative to the source `reference_date`.
 - A collection due tomorrow is rendered in **bold** and at a larger font size than non-tomorrow waste lines.
 - If no matching waste collections fall within the configured look-ahead window, `waste_collection_text` renders a no-collection line instead of leaving the slot empty.
+- `trello_cards` fetches open cards from the configured board and filters to the configured list names when `list_names` is set; when `list_names` is absent all open lists are included.
+- `trello_cards` raises `ValueError` (fast-fail) when `api_key`, `token`, or `board_id` is absent.
+- `trello_cards` maps HTTP, network, and JSON errors to `SourceUnavailableError`.
+- `trello_cards_text` renders cards grouped under their list name (bold header), each card prefixed with `•`.
+- `trello_cards_text` renders `"No cards"` when the source returns an empty card set.

--- a/services/desktop_dashboard_service/architecture/dd-0010-dashboard-layout-specification.md
+++ b/services/desktop_dashboard_service/architecture/dd-0010-dashboard-layout-specification.md
@@ -45,7 +45,7 @@ have one authoritative reference for the visual contract.
 │  CLOCK          │ ─── SEPARATOR (y=182, x=192–794) ───────────────────────────  │
 │  (14,100,154,174)│                                                                │
 │                 │  GCAL BLOCK (196,198,596,124)                                 │
-│  WASTE          │  TRAINS (244,340,548,130)                                     │
+│  WASTE          │  TRAINS (244,340,280,130) │ TRELLO (542,340,250,130)         │
 │  (8,304,168,60) │                                                                 │
 │                 │                                                                 │
 │  MASCOT         │                                                                 │
@@ -68,7 +68,9 @@ box, not the glyph baseline.
 | `SEPARATOR`     | `<line>` element   | 192 | 182 | 602 |   1 | structural |
 | `GCAL`          | `gcal_events`      | 196 | 198 | 596 | 124 | secondary  |
 | `TRAIN_ICON`    | `<path>` element   | 196 | 334 |  44 |  54 | structural |
-| `TRANSPORT`     | `trains` text      | 244 | 340 | 548 | 130 | primary    |
+| `TRANSPORT`     | `trains` text      | 244 | 340 | 280 | 130 | primary    |
+| `TRELLO_DIVIDER`| `<line>` element   | 534 | 334 |   1 | 142 | structural |
+| `TRELLO`        | `trello` text      | 542 | 340 | 250 | 130 | secondary  |
 
 Notes:
 - The DATE text baseline is `y=32`; the region box starts at `y=0` to include ascenders.
@@ -76,9 +78,11 @@ Notes:
   `ca. HH:MM` label while freeing the lower rail for waste collection.
 - WASTE moves into the rail so the main area can devote one flexible block to
   the multi-day calendar renderer.
-- TRANSPORT bottom edge remains `y=470`, leaving a 10 px margin from the canvas bottom.
-- TRANSPORT starts at `y=340`, below the calendar block.
+- TRANSPORT bottom edge is `y=470`, leaving a 10 px margin from the canvas bottom.
+- TRANSPORT starts at `y=340`, below the calendar block; it shares the lower row with TRELLO.
 - TRAIN_ICON top-left is at `(196, 334)`; TRANSPORT text starts at `x=244`.
+- A vertical divider at `x=534` (y=334–476) separates TRANSPORT from TRELLO.
+- TRELLO starts at `x=542`, right edge `x=792`, matching the right edge of all other main-area elements.
 - The gutter between RAIL and MAIN is 5 px (x=183–187); it is intentionally empty.
 - No visible dividers separate regions within the rail; whitespace alone defines zones.
 
@@ -90,7 +94,7 @@ absolute (canvas-relative).
 | Column           | Left edge (x) | Nominal width | Right edge (x) |
 |------------------|--------------|---------------|----------------|
 | Departure time   | 244          | 72 px         | 316            |
-| Destination      | 328          | 464 px        | 792            |
+| Destination      | 328          | 196 px        | 524            |
 
 ---
 
@@ -116,14 +120,20 @@ All sizes are nominal SVG/PIL pixel values at the 800×480 canvas resolution.
 | Transport — station name          | TRANSPORT     | 20        | 700    | normal  |
 | Transport — time                  | TRANSPORT     | 16        | 400    | normal  |
 | Transport — destination           | TRANSPORT     | 16        | 400    | normal  |
+| Trello — list header              | TRELLO        | auto²     | 700    | normal  |
+| Trello — card name                | TRELLO        | auto²     | 400    | normal  |
 
 ¹ GCAL font is auto-sized to fit all visible events in the image height.
+
+² TRELLO font is auto-sized via `data-bbox-width="250"` and `data-bbox-height="130"`.
+`font-size` in `renderer_config` (default 14) sets the nominal size; the SVG renderer
+reduces it automatically when content overflows the bounding box.
 `font-size` in `renderer_config` (default 14) acts as an upper bound; the
 renderer shrinks it so that `ceil(n_events / 2)` rows fit within the slot
 height using the formula `min(font-size, floor(height / (rows_per_col × 1.3)))`.
 Day labels use the bold variant of the same auto-sized font.
 
-Sizing rule: the TRANSPORT slot declares `data-bbox-width="548"` and
+Sizing rule: the TRANSPORT slot declares `data-bbox-width="280"` and
 `data-bbox-height="130"`.  The auto-fit heuristic sizes the overall block first;
 `departure-font-size` in `renderer_config` overrides the computed size (see DD-007).
 `station-name-font-size` sets the station header size independently via `StyledLine`.
@@ -234,8 +244,10 @@ uniform size; position in the list communicates priority.
 
 1. No visible dividing lines within the left rail.  Vertical whitespace between
    DATE, CLOCK, WASTE, and MASCOT is sufficient.
-2. One separator line at `y=182` (stroke ≈ 1–2 px, `#444`) marks the boundary
-   between WEATHER and TRANSPORT.  It is the only structural line on the canvas.
+2. One horizontal separator line at `y=182` (stroke ≈ 1–2 px, `#444`) marks the
+   boundary between WEATHER and the lower information zone.  One vertical separator
+   line at `x=534` (stroke 1 px, `#444`, y=334–476) divides TRANSPORT from TRELLO.
+   These are the only structural lines on the canvas.
 3. Priority is communicated by size and position, not labels or borders.
    The WEATHER block and the NEXT departure are the two largest type elements;
    everything else is smaller.
@@ -256,4 +268,5 @@ uniform size; position in the list communicates priority.
 | DD-009  | Introduced the two-zone grid and the rationale for removing the old free-positioned layout.  This record supersedes DD-009's typography and state notes and adds the complete reference tables. |
 | DD-007  | Defines `TextSpan`, `RichLine`, `StyledLine`, and `data-bbox-*` auto-sizing — the mechanisms used to implement the delayed and cancelled states above. |
 | DD-008  | Defines the MVG FIB v2 departure source that populates TRANSPORT. |
+| (Trello source) | The `trello_cards` source and `trello_cards_text` renderer populate TRELLO.  Credentials (`api_key`, `token`) are supplied via `secrets.toml` placeholders. |
 | ADR-0003 | SVG template as the layout format; the region IDs above are the SVG element `id` values used by that contract. |

--- a/services/desktop_dashboard_service/examples/dashboard_config.toml
+++ b/services/desktop_dashboard_service/examples/dashboard_config.toml
@@ -129,3 +129,23 @@ slot = "image_pool"
 [panels.source_config]
 directory = "./image_samples"
 [panels.renderer_config]
+
+# ---------------------------------------------------------------------------
+# Trello board — uncomment and fill in board_id (and add a matching SVG slot)
+# ---------------------------------------------------------------------------
+[[panels]]
+source = "trello_cards"
+renderer = "trello_cards_text"
+slot = "trello"
+[panels.source_config]
+# ${trello_api_key} and ${trello_token} are substituted from secrets.toml
+api_key  = "${trello_api_key}"
+token    = "${trello_token}"
+board_id = "qUD5teDv"
+# # Optional: limit to specific column names (case-insensitive)
+list_names = ["Diese Woche", "In Arbeit"]
+max_cards = 10
+[panels.renderer_config]
+font-size   = "14"
+font-family = "Arial, sans-serif"
+fill        = "black"

--- a/services/desktop_dashboard_service/examples/layout.svg
+++ b/services/desktop_dashboard_service/examples/layout.svg
@@ -44,8 +44,15 @@
         fill="black"
         d="M184 24H72a32 32 0 0 0-32 32v128a32 32 0 0 0 72 32h8l-14.4 19.2a8 8 0 1 0 12.8 9.6L100 216h56l21.6 28.8a8 8 0 1 0 12.8-9.6L176 216h8a32 32 0 0 0 32-32V56a32 32 0 0 0-32-32M56 120V80h64v40Zm80-40h64v40h-64ZM72 40h112a16 16 0 0 1 16 16v8H56v-8a16 16 0 0 1 16-16m112 160H72a16 16 0 0 1-16-16v-48h144v48a16 16 0 0 1-16 16m-88-28a12 12 0 1 1-12-12a12 12 0 0 1 12 12m88 0a12 12 0 1 1-12-12a12 12 0 0 1 12 12"/>
 
-  <!-- Trains: full-width timetable beneath the calendar block. -->
+  <!-- Trains: left portion of the lower timetable row (narrowed to share with Trello). -->
   <text id="trains" x="244" y="340" font-family="Arial, sans-serif" fill="black"
-        data-bbox-width="548" data-bbox-height="130" />
+        data-bbox-width="280" data-bbox-height="130" />
+
+  <!-- Vertical divider between trains and Trello. -->
+  <line x1="534" y1="334" x2="534" y2="476" stroke="#444" stroke-width="1" />
+
+  <!-- Trello board: lower-right corner, lists cards grouped by column. -->
+  <text id="trello" x="542" y="340" font-family="Arial, sans-serif" fill="black"
+        data-bbox-width="250" data-bbox-height="130" />
 
 </svg>

--- a/services/desktop_dashboard_service/examples/secrets.toml.tmpl
+++ b/services/desktop_dashboard_service/examples/secrets.toml.tmpl
@@ -17,3 +17,8 @@ waste_address = "Ringstr. 12"
 
 # MQTT broker credentials (optional — only needed when the broker requires auth)
 # mqtt_password = "your-mqtt-password"
+
+# Trello — https://trello.com/power-ups/admin → create a Power-Up → get API key
+# Generate a token at: https://trello.com/1/authorize?expiration=never&scope=read&response_type=token&name=ePaperDash&key=YOUR_API_KEY
+# trello_api_key = "your-trello-api-key"
+# trello_token   = "your-trello-read-only-token"

--- a/services/desktop_dashboard_service/src/epaper_dashboard_service/adapters/rendering/trello.py
+++ b/services/desktop_dashboard_service/src/epaper_dashboard_service/adapters/rendering/trello.py
@@ -1,0 +1,56 @@
+"""Trello card text renderer.
+
+Renders open Trello cards as a ``DashboardTextBlock``.  Cards are grouped by
+list name: each list name is emitted as a bold header line, followed by the
+card names prefixed with ``•``.
+"""
+from __future__ import annotations
+
+from epaper_dashboard_service.domain.models import (
+    DashboardTextBlock,
+    PanelDefinition,
+    RichLine,
+    TextSpan,
+    TrelloCards,
+)
+from epaper_dashboard_service.domain.ports import RendererPlugin
+
+
+class TrelloCardsTextRenderer(RendererPlugin):
+    name = "trello_cards_text"
+    supported_type = TrelloCards
+
+    def render(self, data: TrelloCards, panel: PanelDefinition) -> tuple[DashboardTextBlock, ...]:
+        if not data.cards:
+            return (
+                DashboardTextBlock(
+                    slot=panel.slot,
+                    lines=("No cards",),
+                    attributes=_text_attributes(panel),
+                ),
+            )
+
+        lines: list[str | RichLine] = []
+        current_list: str | None = None
+        for card in data.cards:
+            if card.list_name != current_list:
+                current_list = card.list_name
+                lines.append((TextSpan(text=card.list_name, bold=True),))
+            lines.append(f"\u2022 {card.name}")
+
+        return (
+            DashboardTextBlock(
+                slot=panel.slot,
+                lines=tuple(lines),
+                attributes=_text_attributes(panel),
+            ),
+        )
+
+
+def _text_attributes(panel: PanelDefinition) -> dict[str, str]:
+    allowed_keys = {"font-size", "font-family", "font-weight", "fill", "text-anchor"}
+    return {
+        key: str(value)
+        for key, value in panel.renderer_config.items()
+        if key in allowed_keys
+    }

--- a/services/desktop_dashboard_service/src/epaper_dashboard_service/adapters/sources/trello.py
+++ b/services/desktop_dashboard_service/src/epaper_dashboard_service/adapters/sources/trello.py
@@ -1,0 +1,114 @@
+"""Trello source plugin.
+
+Fetches open cards from a configured Trello board, optionally filtered to a
+subset of lists/columns by name.
+
+Configuration keys
+------------------
+``api_key`` (required)
+    Trello API key.  Obtain from https://trello.com/power-ups/admin.
+    Use a ``${trello_api_key}`` placeholder and supply the value via secrets.toml.
+
+``token`` (required)
+    Trello API token with *read-only* scope.
+    Use a ``${trello_token}`` placeholder and supply the value via secrets.toml.
+
+``board_id`` (required)
+    The 24-character board ID or the short name from the board URL.
+
+``list_names`` (optional)
+    List of column names to include (case-insensitive substring match).
+    When omitted, cards from all open lists are returned.
+
+``max_cards`` (optional, default 20)
+    Maximum number of cards to return across all included lists.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from epaper_dashboard_service.domain.errors import SourceUnavailableError
+from epaper_dashboard_service.domain.models import TrelloCard, TrelloCards
+from epaper_dashboard_service.domain.ports import SourcePlugin
+
+_LOGGER = logging.getLogger(__name__)
+_BASE_URL = "https://api.trello.com/1"
+_FETCH_TIMEOUT_SECONDS = 10
+_DEFAULT_MAX_CARDS = 20
+
+
+class TrelloSourcePlugin(SourcePlugin):
+    name = "trello_cards"
+
+    def fetch(self, config: dict[str, Any]) -> TrelloCards:
+        api_key = str(config.get("api_key", "")).strip()
+        token = str(config.get("token", "")).strip()
+        board_id = str(config.get("board_id", "")).strip()
+
+        if not api_key:
+            raise ValueError("trello_cards source requires config value: api_key")
+        if not token:
+            raise ValueError("trello_cards source requires config value: token")
+        if not board_id:
+            raise ValueError("trello_cards source requires config value: board_id")
+
+        max_cards = int(config.get("max_cards", _DEFAULT_MAX_CARDS))
+        list_name_filters = tuple(
+            name.strip().lower() for name in config.get("list_names", [])
+        )
+        base_url = str(config.get("base_url", _BASE_URL)).rstrip("/")
+        auth = {"key": api_key, "token": token}
+
+        try:
+            board_data = _fetch_json(f"{base_url}/boards/{board_id}", {**auth, "fields": "name"})
+            board_name = str(board_data.get("name", board_id))
+
+            lists_data = _fetch_json(
+                f"{base_url}/boards/{board_id}/lists",
+                {**auth, "fields": "id,name", "filter": "open"},
+            )
+            list_id_to_name: dict[str, str] = {item["id"]: item["name"] for item in lists_data}
+
+            if list_name_filters:
+                included_ids = {
+                    list_id
+                    for list_id, list_name in list_id_to_name.items()
+                    if list_name.strip().lower() in list_name_filters
+                }
+            else:
+                included_ids = set(list_id_to_name)
+
+            cards_data = _fetch_json(
+                f"{base_url}/boards/{board_id}/cards",
+                {**auth, "filter": "open", "fields": "name,idList"},
+            )
+        except (URLError, TimeoutError, OSError, json.JSONDecodeError, KeyError, TypeError) as error:
+            raise SourceUnavailableError("trello_cards source unavailable") from error
+
+        cards = tuple(
+            TrelloCard(name=card["name"], list_name=list_id_to_name[card["idList"]])
+            for card in cards_data
+            if card.get("idList") in included_ids
+        )[:max_cards]
+
+        _LOGGER.info("Trello board=%r cards=%d", board_name, len(cards))
+        return TrelloCards(board_name=board_name, cards=cards)
+
+
+def _fetch_json(url: str, params: dict[str, str]) -> Any:
+    full_url = f"{url}?{urlencode(params)}"
+    req = Request(full_url, headers={"Accept": "application/json", "User-Agent": "ePaperDash/1.0"})
+    try:
+        with urlopen(req, timeout=_FETCH_TIMEOUT_SECONDS) as response:
+            return json.loads(response.read())
+    except HTTPError as error:
+        _LOGGER.error("Trello HTTPError url=%s status=%s", url, error.code)
+        raise
+    except URLError as error:
+        _LOGGER.error("Trello URLError url=%s reason=%s", url, error.reason)
+        raise

--- a/services/desktop_dashboard_service/src/epaper_dashboard_service/bootstrap.py
+++ b/services/desktop_dashboard_service/src/epaper_dashboard_service/bootstrap.py
@@ -10,6 +10,7 @@ from epaper_dashboard_service.adapters.rendering.gcal import GoogleCalendarTextR
 from epaper_dashboard_service.adapters.rendering.image import ImagePlacementRenderer
 from epaper_dashboard_service.adapters.rendering.text import CalendarTextRenderer, WeatherTextRenderer
 from epaper_dashboard_service.adapters.rendering.train import TrainDepartureTextRenderer
+from epaper_dashboard_service.adapters.rendering.trello import TrelloCardsTextRenderer
 from epaper_dashboard_service.adapters.rendering.waste import WasteCollectionTextRenderer
 from epaper_dashboard_service.adapters.rendering.weather import WeatherBlockRenderer
 from epaper_dashboard_service.adapters.sources.calendar import CalendarSourcePlugin
@@ -17,6 +18,7 @@ from epaper_dashboard_service.adapters.sources.clock import ClockSourcePlugin
 from epaper_dashboard_service.adapters.sources.google_calendar import GoogleCalendarSourcePlugin
 from epaper_dashboard_service.adapters.sources.mvg import MvgDepartureSourcePlugin
 from epaper_dashboard_service.adapters.sources.random_image import RandomImageSourcePlugin
+from epaper_dashboard_service.adapters.sources.trello import TrelloSourcePlugin
 from epaper_dashboard_service.adapters.sources.waste import FfbWasteCollectionSourcePlugin
 from epaper_dashboard_service.adapters.sources.weather import WeatherForecastSourcePlugin
 from epaper_dashboard_service.application.service import DashboardApplicationService, PluginRegistry
@@ -36,6 +38,7 @@ def build_application(mqtt_config: MqttConfig) -> DashboardApplicationService:
             ClockSourcePlugin(),
             GoogleCalendarSourcePlugin(),
             FfbWasteCollectionSourcePlugin(),
+            TrelloSourcePlugin(),
         ),
         renderers=(
             CalendarTextRenderer(),
@@ -46,6 +49,7 @@ def build_application(mqtt_config: MqttConfig) -> DashboardApplicationService:
             AnalogClockRenderer(),
             GoogleCalendarTextRenderer(),
             WasteCollectionTextRenderer(),
+            TrelloCardsTextRenderer(),
         ),
     )
     return DashboardApplicationService(

--- a/services/desktop_dashboard_service/src/epaper_dashboard_service/domain/models.py
+++ b/services/desktop_dashboard_service/src/epaper_dashboard_service/domain/models.py
@@ -145,6 +145,18 @@ class WasteCollectionSchedule:
 
 
 @dataclass(frozen=True)
+class TrelloCard:
+    name: str
+    list_name: str
+
+
+@dataclass(frozen=True)
+class TrelloCards:
+    board_name: str
+    cards: tuple[TrelloCard, ...]
+
+
+@dataclass(frozen=True)
 class PanelDefinition:
     source: str
     renderer: str


### PR DESCRIPTION
Add a read-only Trello data source and text renderer so a configured board's cards can be displayed on the dashboard.

New code
- domain/models.py: TrelloCard and TrelloCards dataclasses
- adapters/sources/trello.py: TrelloSourcePlugin (name=trello_cards) · fetches board metadata, open lists, and open cards via the Trello REST API using only stdlib urllib — no new dependencies · filters cards to configured list_names (case-insensitive substring) · maps all HTTP / network / JSON errors to SourceUnavailableError · raises ValueError fast-fail when api_key, token, or board_id absent
- adapters/rendering/trello.py: TrelloCardsTextRenderer (name=trello_cards_text) · groups cards under bold list-name headers, each card prefixed with • · renders 'No cards' when the board returns an empty set
- bootstrap.py: registers both plugins

Configuration
- examples/secrets.toml.tmpl: added trello_api_key / trello_token placeholders with token-generation URL comment
- examples/dashboard_config.toml: commented-out example [[panels]] block showing api_key / token placeholders, board_id, list_names, max_cards

Layout
- examples/layout.svg: split the lower main row at x=534; trains slot narrowed to w=280 (x 244–524), new trello slot w=250 (x 542–792), vertical divider line at x=534

Spec updates
- architecture/dd-0010-dashboard-layout-specification.md: updated zone map, region table (TRANSPORT w=280, new TRELLO_DIVIDER and TRELLO rows), notes, transport column layout (destination right edge 524), bbox widths, typography scale (Trello rows + footnote), whitespace rule 2, and relationship table
- architecture/current-specification.md: added trello_cards source and trello_cards_text renderer to plugin inventory; updated acceptance criteria bounding-box note; added four Trello acceptance criteria